### PR TITLE
Added convenience target mimaPreviousVersions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -63,6 +63,10 @@ class itestCross(millVersion: String) extends MillIntegrationTestModule {
         PathRef(testBase / "filters") -> Seq(
           TestInvocation.Targets(Seq("prepare")),
           TestInvocation.Targets(Seq("verify"))
+        ),
+        PathRef(testBase / "previous-versions") -> Seq(
+          TestInvocation.Targets(Seq("prepare")),
+          TestInvocation.Targets(Seq("verify"), expectedExitCode = 1)
         )
       )
     }

--- a/itest/src/previous-versions/build.sc
+++ b/itest/src/previous-versions/build.sc
@@ -1,0 +1,39 @@
+import $exec.plugins
+
+import com.github.lolgab.mill.mima._
+import mill._
+import mill.scalalib._
+import mill.scalalib.publish._
+import mill.scalajslib.ScalaJSModule
+
+trait Common extends ScalaModule with PublishModule with Mima { outer =>
+  def scalaVersion = "2.13.6"
+  def publishVersion = "0.0.1"
+  def pomSettings =
+    PomSettings("", organization = "org", "", Seq(), VersionControl(), Seq())
+  trait Js extends Common with ScalaJSModule {
+    override def scalaJSVersion = "1.6.0"
+    override def mimaPreviousVersions = outer.mimaPreviousVersions
+  }
+}
+object prev extends Common {
+  object js extends Js
+}
+object curr extends Common with Mima { outer =>
+  override def mimaPreviousVersions = T(Seq("0.0.1"))
+  object js extends Js
+}
+
+def prepare() = T.command {
+  prev.publishLocal(sys.props("ivy.home") + "/local")()
+  prev.js.publishLocal(sys.props("ivy.home") + "/local")()
+}
+
+def verify() = T.command {
+  // tests mimaPreviousVersions
+  assert(curr.mimaPreviousArtifacts() == Agg(ivy"org::prev:0.0.1"))
+  assert(curr.js.mimaPreviousArtifacts() == Agg(ivy"org::prev::0.0.1"))
+  // tests resolution and issue reporting
+  curr.mimaReportBinaryIssues()()
+  curr.js.mimaReportBinaryIssues()()
+}

--- a/itest/src/previous-versions/curr/src/Main.scala
+++ b/itest/src/previous-versions/curr/src/Main.scala
@@ -1,0 +1,1 @@
+object Main {}

--- a/itest/src/previous-versions/prev/src/Main.scala
+++ b/itest/src/previous-versions/prev/src/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def hello(): String = "Hello world!"
+}

--- a/itest/src/simple/build.sc
+++ b/itest/src/simple/build.sc
@@ -1,7 +1,6 @@
 import mill._, mill.scalalib._, mill.scalalib.publish._
 import $exec.plugins
 import com.github.lolgab.mill.mima._
-import coursier.ivy.IvyRepository
 
 trait Common extends ScalaModule with PublishModule {
   def scalaVersion = "2.13.4"
@@ -11,7 +10,7 @@ trait Common extends ScalaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  def mimaPreviousVersions = T(Seq("0.0.1"))
+  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
 }
 
 def prepare() = T.command {
@@ -19,9 +18,6 @@ def prepare() = T.command {
 }
 
 def verify() = T.command {
-  // tests mimaPreviousVersions
-  assert(curr.mimaPreviousArtifacts() == Agg(ivy"org::prev:0.0.1"))
-  // tests resolution and issue reporting
   curr.mimaReportBinaryIssues()()
   ()
 }

--- a/itest/src/simple/build.sc
+++ b/itest/src/simple/build.sc
@@ -11,7 +11,7 @@ trait Common extends ScalaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
+  def mimaPreviousVersions = T(Seq("0.0.1"))
 }
 
 def prepare() = T.command {
@@ -19,5 +19,9 @@ def prepare() = T.command {
 }
 
 def verify() = T.command {
-  curr.mimaReportBinaryIssues()
+  // tests mimaPreviousVersions
+  assert(curr.mimaPreviousArtifacts() == Agg(ivy"org::prev:0.0.1"))
+  // tests resolution and issue reporting
+  curr.mimaReportBinaryIssues()()
+  ()
 }

--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -33,7 +33,7 @@ trait Mima extends ScalaModule with PublishModule {
       Result.Success(
         Agg.from(
           versions.map(version =>
-            ivy"${pomSettings().organization}:${artifactId()}::${version}"
+            ivy"${pomSettings().organization}:${artifactId()}:${version}"
           )
         )
       )

--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -33,7 +33,7 @@ trait Mima extends ScalaModule with PublishModule {
       Result.Success(
         Agg.from(
           versions.map(version =>
-            ivy"${pomSettings().organization}:${artifactId()}:${version}"
+            ivy"${pomSettings().organization}:${artifactId()}::${version}"
           )
         )
       )

--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -17,7 +17,7 @@ import mill.scalalib.api.Util.scalaBinaryVersion
 trait Mima extends ScalaModule with PublishModule {
 
   /** Set of versions to check binary compatibility against. */
-  def mimaPreviousVersions: Target[Seq[String]] = Seq()
+  def mimaPreviousVersions: Target[Seq[String]] = T { Seq.empty[String] }
 
   /** Set of artifacts to check binary compatibility against. By default this is
     * derived from [[mimaPreviousVersions]].

--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -15,7 +15,29 @@ import mill.scalalib._
 import mill.scalalib.api.Util.scalaBinaryVersion
 
 trait Mima extends ScalaModule with PublishModule {
-  def mimaPreviousArtifacts: Target[Agg[Dep]]
+
+  /** Set of versions to check binary compatibility against. */
+  def mimaPreviousVersions: Target[Seq[String]] = Seq()
+
+  /** Set of artifacts to check binary compatibility against. By default this is
+    * derived from [[mimaPreviousVersions]].
+    */
+  def mimaPreviousArtifacts: Target[Agg[Dep]] = T {
+    val versions = mimaPreviousVersions().distinct
+    if (versions.isEmpty)
+      Result.Failure(
+        "No previous artifacts configured. Please override mimaPreviousVersions or mimaPreviousArtifacts.",
+        Some(Agg.empty[Dep])
+      )
+    else
+      Result.Success(
+        Agg.from(
+          versions.map(version =>
+            ivy"${pomSettings().organization}:${artifactId()}:${version}"
+          )
+        )
+      )
+  }
 
   def mimaCheckDirection: Target[CheckDirection] = T { CheckDirection.Backward }
 


### PR DESCRIPTION
If defined, `mimaPreviousArtifacts` is computed from `mimaPreviousVersions` and the self organization and artifact name.

I have no idea how lean do you plan your API, but I think this only adds what most users will do anyways.