### PR TITLE
Correct hint in error message to match plugin's ProblemFilter class

### DIFF
--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -159,7 +159,9 @@ trait Mima
 
   private def prettyProblem(affected: String)(p: Problem): String = {
     val desc = p.description(affected)
-    val howToFilter = p.howToFilter.fold("")(s => s"\n   filter with: $s")
+    val howToFilter = p.howToFilter.fold("")(s =>
+      s"\n   filter with: ${s.replace("ProblemFilters.exclude", ("ProblemFilter.exclude"))}"
+    )
     s" * $desc$howToFilter"
   }
 


### PR DESCRIPTION
As this plugin comes with it's own ProblemFilter class which has a
different name, the helpful error message of MiMa can't be copy-and-pasted.
This PR replaces the string to allow copy-and-paste-ing.
