### PR TITLE
dep: start using mill-dependency-submission

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -5,11 +5,8 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
 jobs:
-  dependency-update:
+  submit-dependency-graph:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +15,4 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-
-      - name: Submit dependency graph
-        run: ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.9 io.kipp.mill.github.dependency.graph.Graph/submit
+      - uses: ckipp01/mill-dependency-submission@v1


### PR DESCRIPTION
`mill-dependency-submission` is a GitHub action that makes using
`mill-github-dependency-graph` a bit easier. This way dependabot can
also update the version of the action for you if you want. This also
uses a newer version of the plugin that brings in some nice bug fixes.