### PR TITLE
Add `MIMA_CHECK_DIRECTION` environment input for direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,29 @@ object module extends ScalaModule with PublishModule with Mima {
 
 ### mimaCheckDirection
 
-The required direction of binary compatibility can be set by overriding `mimaCheckDirection`:
+The required direction of binary compatibility can be set in two ways:
 
-```scala
-override def mimaCheckDirection = CheckDirection.Both
-```
+- By setting the `MIMA_CHECK_DIRECTION` environment variable when running Mill
+  ```
+  MIMA_CHECK_DIRECTION=forward mill __.mimaReportBinaryIssues
+  ```
 
-The possible directions are `Backward` (default), `Forward` and `Both`.
+  The possible values are `backward` (default), `forward` and `both`.
+
+  This is useful when you want to check for different directions at the same time,
+  for example when you might want to have separate CI checks for forward and
+  backward compatibility to evaluate if changes introduce source compatibilities.
+
+- By overriding `mimaCheckDirection`:
+
+  ```scala
+  override def mimaCheckDirection = CheckDirection.Both
+  ```
+
+  The possible values are `CheckDirection.Backward` (default), `CheckDirection/Forward` and `CheckDirection.Both`.
+
+  This is useful when the setting is static and you want to keep the setting in
+  your `build.sc` file.
 
 ### mimaBinaryIssueFilters
 

--- a/build.sc
+++ b/build.sc
@@ -1,11 +1,9 @@
 import mill._
-
 import mill.scalalib._
 import mill.scalalib.api.Util.scalaNativeBinaryVersion
 import mill.scalalib.publish._
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:`
 import mill.contrib.buildinfo.BuildInfo
-import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 import $ivy.`de.tototec::de.tobiasroeser.mill.integrationtest::0.6.1`
 import de.tobiasroeser.mill.integrationtest._
 import $ivy.`com.goyeau::mill-scalafix::0.2.11`
@@ -53,9 +51,7 @@ class MillMimaCross(val millBinaryVersion: String)
   override def moduleDeps = super.moduleDeps ++ Seq(`mill-mima-worker-api`)
   override def artifactName = s"mill-mima_mill$millBinaryVersion"
   override def millSourcePath = super.millSourcePath / os.up
-  def mimaPreviousArtifacts = Agg(
-    ivy"com.github.lolgab::mima_mill$millBinaryVersion:0.0.1"
-  )
+  def mimaPreviousVersions = Seq("0.0.17")
   override def sources = T.sources(
     super.sources() ++ Seq(
       millSourcePath / s"src-mill${millVersion(millBinaryVersion).split('.').take(2).mkString(".")}"

--- a/mill-mima/src/com/github/lolgab/mill/mima/CheckDirection.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/CheckDirection.scala
@@ -2,7 +2,7 @@ package com.github.lolgab.mill.mima
 
 import upickle.default._
 
-sealed trait CheckDirection
+sealed trait CheckDirection extends Product with Serializable
 object CheckDirection {
   case object Backward extends CheckDirection
   case object Forward extends CheckDirection

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -41,7 +41,22 @@ private[mima] trait MimaBase
       )
   }
 
-  def mimaCheckDirection: Target[CheckDirection] = T { CheckDirection.Backward }
+  private def mimaCheckDirectionInput = T.input {
+    T.env.get("MIMA_CHECK_DIRECTION")
+  }
+
+  /** Compatibility checking direction. */
+  def mimaCheckDirection: Target[CheckDirection] = T {
+    mimaCheckDirectionInput() match {
+      case Some("both")            => Result.Success(CheckDirection.Both)
+      case Some("forward")         => Result.Success(CheckDirection.Forward)
+      case Some("backward") | None => Result.Success(CheckDirection.Backward)
+      case Some(other) =>
+        Result.Failure(
+          s"Invalid check direction \"$other\". Valid values are \"backward\", \"forward\" or \"both\"."
+        )
+    }
+  }
 
   private[mima] def resolvedMimaPreviousArtifacts: T[Agg[(Dep, PathRef)]] = T {
     resolveSeparateNonTransitiveDeps(mimaPreviousArtifacts)().map(p =>


### PR DESCRIPTION
This allows people to dynamically check for different directions, for example having multiple Github Actions checks for, one with `backward` and one with `forward` to check if source compatibility might be broken.