### PR TITLE
Add support to build and publish against the latest Mill dev version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,6 @@ jobs:
         java-version: "8"
         architecture: "x64"
         distribution: "temurin"
-    - name: Add latest Mill dev version
-      if: github.event_name == 'workflow_dispatch'
-      run:
-          ./mill --no-server--disable-ticker findLatestMill --toFile MILL_DEV_VERSION
     - name: Check formatting
       run: 
         ./mill --no-server --disable-ticker mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
@@ -65,10 +61,6 @@ jobs:
           java-version: "8"
           architecture: "x64"
           distribution: "temurin"
-      - name: Add latest Mill dev version
-        if: github.event_name == 'workflow_dispatch'
-        run:
-          ./mill --no-server--disable-ticker findLatestMill --toFile MILL_DEV_VERSION
       - name: Publish to Maven Central
         run: |
           if [[ $(git tag --points-at HEAD) != '' ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,25 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: coursier/cache-action@v6
     - uses: actions/setup-java@v3
       with:
         java-version: "8"
         architecture: "x64"
         distribution: "temurin"
+    - name: Add latest Mill dev version
+      if: github.event_name == 'workflow_dispatch'
+      run:
+          ./mill --no-server--disable-ticker findLatestMill --toFile MILL_DEV_VERSION
     - name: Check formatting
       run: 
         ./mill --no-server --disable-ticker mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
@@ -37,7 +44,7 @@ jobs:
       run:
         ./mill --no-server --disable-ticker __.test
   publish-sonatype:
-    if: github.repository == 'lolgab/mill-mima' && contains(github.ref, 'refs/tags/')
+    if: github.repository == 'lolgab/mill-mima' && (contains(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-22.04
     env:
@@ -50,12 +57,18 @@ jobs:
       LC_ALL: "en_US.UTF-8"
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: coursier/cache-action@v6
       - uses: actions/setup-java@v3
         with:
           java-version: "8"
           architecture: "x64"
           distribution: "temurin"
+      - name: Add latest Mill dev version
+        if: github.event_name == 'workflow_dispatch'
+        run:
+          ./mill --no-server--disable-ticker findLatestMill --toFile MILL_DEV_VERSION
       - name: Publish to Maven Central
         run: |
           if [[ $(git tag --points-at HEAD) != '' ]]; then

--- a/build.sc
+++ b/build.sc
@@ -15,6 +15,7 @@ import com.github.lolgab.mill.mima._
 import os.Path
 import scala.util.Try
 
+val stableVersions = Seq("0.9.12", "0.10.0", "0.11.0-M8")
 val latestMillDevVersion: Option[String] = {
   val path = build.millSourcePath / "MILL_DEV_VERSION"
   interp.watch(path)
@@ -24,9 +25,8 @@ val latestMillDevVersion: Option[String] = {
       .recover { _ => None }
   }.get
   else None
-}
+}.filter(!stableVersions.contains(_))
 
-val stableVersions = Seq("0.9.12", "0.10.0", "0.11.0-M8")
 val millVersions = stableVersions ++ latestMillDevVersion
 val millBinaryVersions = stableVersions.map(
   scalaNativeBinaryVersion

--- a/utils.sc
+++ b/utils.sc
@@ -1,0 +1,10 @@
+import coursier._
+import scala.concurrent.duration._
+
+def findLatestDevVersion(): String = {
+  val versions =
+    Versions(cache.FileCache().withTtl(1.minute))
+      .withModule(mod"com.lihaoyi:mill-main_2.13")
+      .run()
+  versions.latest
+}


### PR DESCRIPTION
* Enable the workflow described in https://github.com/com-lihaoyi/mill/issues/2466#issuecomment-1537986552.

- Added support to lookup and build against the latest Mill dev version
- Publish on `workflow_dispatch` and include build for latest Mill dev version
