### PR TITLE
Use the `jar` to check binary compatibility

### DIFF
--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -116,7 +116,7 @@ private[mima] trait MimaBase
       log.outputStream.println(_)
     val runClasspathIO =
       runClasspath().view.map(_.path).filter(os.exists).map(_.toIO).toArray
-    val current = compile().classes.path.pipe {
+    val current = jar().path.pipe {
       case p if os.exists(p) => p
       case _                 => (T.dest / "emptyClasses").tap(os.makeDir)
     }.toIO


### PR DESCRIPTION
This makes sure we also take all potential post processing (filtering, shading, OSGi bundling) into account.
We check compatibility against previously released `jar`s, so we need to apply the full tooling to get the `jar`.
