### PR TITLE
Make the current artifact configurable and default to use the `jar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ def mimaPreviousArtifacts = Agg(
 )
 ```
 
+### mimaCurrentArtifact
+
+The `PathRef` to the actual artifact that is being checked for binary compatibility. Defaults to use the result of the `jar` target.
+
+_Up until version `0.0.24`, this was implemented as `compile().classes`, for compatibility to the sbt plugin._
+
+```scala
+def mimaCurrentArtifact = T {
+  compile().classes
+}
+```
+
 ### mimaBackwardIssueFilters
 
 Filters to apply to binary issues found grouped by version of a module

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -105,15 +105,12 @@ private[mima] trait MimaBase
     MimaWorkerExternalModule.mimaWorker().impl(cp)
   }
 
-  /**
-   *
-   * The `PathRef` to the actual artifact that is being checked for binary compatibility.
-   * Defaults to use the result of the [[jar]] target.
-   *
-   * Up until version mill-mima `0.0.24`, this was implemented as [[compile]]`().classes`,
-   * for compatibility to the sbt plugin.
-   *
-   */
+  /** The `PathRef` to the actual artifact that is being checked for binary
+    * compatibility. Defaults to use the result of the [[jar]] target.
+    *
+    * Up until version mill-mima `0.0.24`, this was implemented as
+    * [[compile]]`().classes`, for compatibility to the sbt plugin.
+    */
   def mimaCurrentArtifact: T[PathRef] = T { jar() }
 
   def mimaReportBinaryIssues(): Command[Unit] = T.command {

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -105,7 +105,7 @@ private[mima] trait MimaBase
     MimaWorkerExternalModule.mimaWorker().impl(cp)
   }
 
-  def mimaCurrentArtifact: T[PathRef] = T { compile().classes }
+  def mimaCurrentArtifact: T[PathRef] = T { jar() }
 
   def mimaReportBinaryIssues(): Command[Unit] = T.command {
     def prettyDep(dep: Dep): String = {

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -105,6 +105,8 @@ private[mima] trait MimaBase
     MimaWorkerExternalModule.mimaWorker().impl(cp)
   }
 
+  def mimaCurrentArtifact: T[PathRef] = T { compile().classes }
+
   def mimaReportBinaryIssues(): Command[Unit] = T.command {
     def prettyDep(dep: Dep): String = {
       s"${dep.dep.module.orgName}:${dep.dep.version}"
@@ -116,7 +118,7 @@ private[mima] trait MimaBase
       log.outputStream.println(_)
     val runClasspathIO =
       runClasspath().view.map(_.path).filter(os.exists).map(_.toIO).toArray
-    val current = compile().classes.path.pipe {
+    val current = mimaCurrentArtifact().path.pipe {
       case p if os.exists(p) => p
       case _                 => (T.dest / "emptyClasses").tap(os.makeDir)
     }.toIO

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -105,6 +105,15 @@ private[mima] trait MimaBase
     MimaWorkerExternalModule.mimaWorker().impl(cp)
   }
 
+  /**
+   *
+   * The `PathRef` to the actual artifact that is being checked for binary compatibility.
+   * Defaults to use the result of the [[jar]] target.
+   *
+   * Up until version mill-mima `0.0.24`, this was implemented as [[compile]]`().classes`,
+   * for compatibility to the sbt plugin.
+   *
+   */
   def mimaCurrentArtifact: T[PathRef] = T { jar() }
 
   def mimaReportBinaryIssues(): Command[Unit] = T.command {


### PR DESCRIPTION
This enhances the flexibility of the plugin. It defaults to `jar` to also take all potential post processing (filtering, shading, OSGi bundling) into account.
This is IMHO a better default then `compile().classes`, but if someone needs the old behavior, it's now configurable.
