### PR TITLE
Make scalafmt action run on push

### DIFF
--- a/.github/workflows/scalafmt.yml
+++ b/.github/workflows/scalafmt.yml
@@ -1,7 +1,7 @@
 name: scalafmt
 
 on:
-  - pull_request
+  - push
 
 jobs:
   scalafmt:


### PR DESCRIPTION
pull_request doesn't pass GITHUB_TOKEN to forks
push will use the GITHUB_TOKEN of the fork