### PR TITLE
Support pure `JavaModule`s

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -126,7 +126,12 @@ trait itestCross extends MillIntegrationTestModule with Cross.Module[String] {
           TestInvocation.Targets(Seq("prepare")),
           TestInvocation.Targets(Seq("verify")),
           TestInvocation.Targets(Seq("verifyFail"), expectedExitCode = 1)
-        )
+        ),
+        PathRef(testBase / "java") -> Seq(
+          TestInvocation.Targets(Seq("prepare")),
+          TestInvocation.Targets(Seq("verify"), expectedExitCode = 1)
+        ),
+
       )
     }
 }

--- a/itest/src/java/build.sc
+++ b/itest/src/java/build.sc
@@ -12,7 +12,7 @@ trait Common extends JavaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  override def mimaPreviousVersions = T(Seq("0.0.1"))
+  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
   override def mimaCheckDirection = CheckDirection.Backward
 }
 

--- a/itest/src/java/build.sc
+++ b/itest/src/java/build.sc
@@ -1,0 +1,26 @@
+import mill._
+
+import mill.scalalib._
+import mill.scalalib.publish._
+import $file.plugins
+import com.github.lolgab.mill.mima._
+
+trait Common extends JavaModule with PublishModule {
+  def publishVersion = "0.0.1"
+  def pomSettings =
+    PomSettings("", organization = "org", "", Seq(), VersionControl(), Seq())
+}
+object prev extends Common
+object curr extends Common with Mima {
+  override def mimaPreviousVersions = T(Seq("0.0.1"))
+  override def mimaCheckDirection = CheckDirection.Backward
+}
+
+def prepare() = T.command {
+  prev.publishLocal(sys.props("ivy.home") + "/local")()
+}
+
+def verify() = T.command {
+  curr.mimaReportBinaryIssues()()
+  ()
+}

--- a/itest/src/java/build.sc
+++ b/itest/src/java/build.sc
@@ -12,7 +12,7 @@ trait Common extends JavaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
+  override def mimaPreviousArtifacts = T(Agg(ivy"org:prev:0.0.1"))
   override def mimaCheckDirection = CheckDirection.Backward
 }
 

--- a/itest/src/java/curr/src/Main.java
+++ b/itest/src/java/curr/src/Main.java
@@ -1,0 +1,2 @@
+public class Main {
+}

--- a/itest/src/java/prev/src/Main.java
+++ b/itest/src/java/prev/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+  public static String hello() {
+    return "Hello world!";
+  }
+}

--- a/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.java
+++ b/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.java
@@ -1,8 +1,8 @@
 package com.github.lolgab.mill.mima.worker.api;
 
 public interface MimaWorkerApi {
-  java.util.Optional<String> reportBinaryIssues(
-    String scalaBinaryVersion,
+  String reportBinaryIssues(
+    String scalaBinaryVersionOrNull,
     java.util.function.Consumer<String> logDebug,
     java.util.function.Consumer<String> logError,
     java.util.function.Consumer<String> logPrintln,

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
 private[mima] trait MimaBase
-    extends ScalaModule
+    extends JavaModule
     with PublishModule
     with ExtraCoursierSupport
     with VersionSpecific {
@@ -161,8 +161,15 @@ private[mima] trait MimaBase
         .toMap
         .asJava
 
+    // only used for some sanity checks
+    val scalaBinVersion = this match {
+      case m: ScalaModule => scalaBinaryVersion(m.scalaVersion())
+      case _ =>
+        "2.13" // FIXME: ask Mill, but `mill.main.BuildInfo` isn't available in older versions
+    }
+
     val errorOpt: java.util.Optional[String] = mimaWorker().reportBinaryIssues(
-      scalaBinaryVersion(scalaVersion()),
+      scalaBinVersion,
       logDebug,
       logError,
       logPrintln,

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -114,9 +114,9 @@ private[mima] trait MimaBase
   def mimaCurrentArtifact: T[PathRef] = T { jar() }
 
   def mimaReportBinaryIssues(): Command[Unit] = {
-    val scalaBinVersionOrNullTask = this match {
-      case m: ScalaModule => T.task { scalaBinaryVersion(m.scalaVersion()) }
-      case _              => T.task { null }
+    val scalaBinVersionOrNullTask: Task[Option[String]] = this match {
+      case m: ScalaModule => T.task { Some(scalaBinaryVersion(m.scalaVersion())) }
+      case _              => T.task { None }
     }
     T.command {
       def prettyDep(dep: Dep): String = {
@@ -168,7 +168,7 @@ private[mima] trait MimaBase
 
       val errorOrNull: String =
         mimaWorker().reportBinaryIssues(
-          scalaBinVersionOrNullTask(),
+          scalaBinVersionOrNullTask().getOrElse(null),
           logDebug,
           logError,
           logPrintln,

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -169,7 +169,7 @@ private[mima] trait MimaBase
 
       val errorOrNull: String =
         mimaWorker().reportBinaryIssues(
-          scalaBinVersionOrNullTask().getOrElse(null),
+          scalaBinVersionOrNullTask().orNull,
           logDebug,
           logError,
           logPrintln,

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -117,9 +117,7 @@ private[mima] trait MimaBase
     // only used for some sanity checks
     val scalaBinVersionTask = this match {
       case m: ScalaModule => T.task { scalaBinaryVersion(m.scalaVersion()) }
-      case _              =>
-        // FIXME: ask Mill, but `mill.main.BuildInfo` isn't available in older versions
-        T.task("2.13")
+      case _              => T.task("3")
     }
     T.command {
       def prettyDep(dep: Dep): String = {

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -115,8 +115,9 @@ private[mima] trait MimaBase
 
   def mimaReportBinaryIssues(): Command[Unit] = {
     val scalaBinVersionOrNullTask: Task[Option[String]] = this match {
-      case m: ScalaModule => T.task { Some(scalaBinaryVersion(m.scalaVersion())) }
-      case _              => T.task { None }
+      case m: ScalaModule =>
+        T.task { Some(scalaBinaryVersion(m.scalaVersion())) }
+      case _ => T.task { None }
     }
     T.command {
       def prettyDep(dep: Dep): String = {

--- a/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/MimaBase.scala
@@ -117,8 +117,9 @@ private[mima] trait MimaBase
     // only used for some sanity checks
     val scalaBinVersionTask = this match {
       case m: ScalaModule => T.task { scalaBinaryVersion(m.scalaVersion()) }
-      case _ =>
-        T.task("2.13") // FIXME: ask Mill, but `mill.main.BuildInfo` isn't available in older versions
+      case _              =>
+        // FIXME: ask Mill, but `mill.main.BuildInfo` isn't available in older versions
+        T.task("2.13")
     }
     T.command {
       def prettyDep(dep: Dep): String = {
@@ -168,21 +169,22 @@ private[mima] trait MimaBase
           .toMap
           .asJava
 
-      val errorOpt: java.util.Optional[String] = mimaWorker().reportBinaryIssues(
-        scalaBinVersionTask(),
-        logDebug,
-        logError,
-        logPrintln,
-        checkDirection,
-        runClasspathIO,
-        previous,
-        current,
-        binaryFilters,
-        backwardFilters,
-        forwardFilters,
-        mimaExcludeAnnotations().toArray,
-        publishVersion()
-      )
+      val errorOpt: java.util.Optional[String] =
+        mimaWorker().reportBinaryIssues(
+          scalaBinVersionTask(),
+          logDebug,
+          logError,
+          logPrintln,
+          checkDirection,
+          runClasspathIO,
+          previous,
+          current,
+          binaryFilters,
+          backwardFilters,
+          forwardFilters,
+          mimaExcludeAnnotations().toArray,
+          publishVersion()
+        )
 
       if (errorOpt.isPresent()) Result.Failure(errorOpt.get())
       else Result.Success(())


### PR DESCRIPTION
Looks like there is no need for being a `ScalaModule` at all.
There is some sanity check, but it looks like not really needed.

Fix https://github.com/lolgab/mill-mima/issues/154

I also fixed an unrelated issue with `ExtraCoursierSupport`, which was inheriting `ScalaModule`. Instead of extending `ScalaModule` it should use the `bindDependency` task provided for exactly that use case by `CoursierSupport`. Without this fix, extending `ExtraCoursierSupport` can be problematic in downstream modules.