### PR TITLE
Make MiMa not extend `PublishModule`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -131,6 +131,10 @@ trait itestCross extends MillIntegrationTestModule with Cross.Module[String] {
           TestInvocation.Targets(Seq("prepare")),
           TestInvocation.Targets(Seq("verify"), expectedExitCode = 1)
         ),
+        PathRef(testBase / "not-publish-module") -> Seq(
+          TestInvocation.Targets(Seq("prepare")),
+          TestInvocation.Targets(Seq("verify"), expectedExitCode = 1)
+        ),
 
       )
     }

--- a/itest/src/not-publish-module/build.sc
+++ b/itest/src/not-publish-module/build.sc
@@ -1,0 +1,26 @@
+import mill._
+
+import mill.scalalib._
+import mill.scalalib.publish._
+import $file.plugins
+import com.github.lolgab.mill.mima._
+
+object prev extends ScalaModule with PublishModule {
+  def scalaVersion = "2.13.4"
+  def publishVersion = "0.0.1"
+  def pomSettings =
+    PomSettings("", organization = "org", "", Seq(), VersionControl(), Seq())
+}
+object curr extends ScalaModule with Mima {
+  def scalaVersion = "2.13.4"
+  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
+}
+
+def prepare() = T.command {
+  prev.publishLocal(sys.props("ivy.home") + "/local")()
+}
+
+def verify() = T.command {
+  curr.mimaReportBinaryIssues()()
+  ()
+}

--- a/itest/src/not-publish-module/curr/src/Main.scala
+++ b/itest/src/not-publish-module/curr/src/Main.scala
@@ -1,0 +1,1 @@
+object Main {}

--- a/itest/src/not-publish-module/prev/src/Main.scala
+++ b/itest/src/not-publish-module/prev/src/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def hello(): String = "Hello world!"
+}

--- a/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.scala
+++ b/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.scala
@@ -16,7 +16,7 @@ trait MimaWorkerApi {
       backwardFilters: Map[String, Seq[ProblemFilter]],
       forwardFilters: Map[String, Seq[ProblemFilter]],
       excludeAnnos: Seq[String],
-      publishVersion: String
+      publishVersion: Option[String]
   ): Option[String]
 }
 

--- a/mill-mima-worker-impl/src/com/github/lolgab/mill/mima/worker/MimaWorkerImpl.scala
+++ b/mill-mima-worker-impl/src/com/github/lolgab/mill/mima/worker/MimaWorkerImpl.scala
@@ -22,7 +22,7 @@ class MimaWorkerImpl extends MimaWorkerApi {
       backwardFilters: Map[String, Seq[ProblemFilter]],
       forwardFilters: Map[String, Seq[ProblemFilter]],
       excludeAnnos: Seq[String],
-      publishVersion: String
+      publishVersion: Option[String]
   ): Option[String] = {
     sanityCheckScalaBinaryVersion(scalaBinaryVersion)
 

--- a/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/MyProblemReporting.scala
+++ b/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/MyProblemReporting.scala
@@ -5,21 +5,9 @@ private[com] object MyProblemReporting {
       versionOpt: Option[String],
       filters: Seq[ProblemFilter],
       versionedFilters: Map[String, Seq[ProblemFilter]]
-  )(problem: Problem): Boolean = {
-    val versionMatchingFilters = versionOpt match {
-      case None => Seq.empty
-      case Some(version) =>
-        versionedFilters
-          // get all filters that apply to given module version or any version after it
-          .collect {
-            case (version2, filters)
-                if ProblemReporting.versionOrdering.gteq(version2, version) =>
-              filters
-          }.flatten
-    }
-
-    (versionMatchingFilters.iterator ++ filters).forall(filter =>
-      filter(problem)
-    )
+  )(problem: Problem): Boolean = versionOpt match {
+    case None => filters.forall(_(problem))
+    case Some(version) =>
+      ProblemReporting.isReported(version, filters, versionedFilters)(problem)
   }
 }

--- a/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/MyProblemReporting.scala
+++ b/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/MyProblemReporting.scala
@@ -1,0 +1,25 @@
+package com.typesafe.tools.mima.core
+
+private[com] object MyProblemReporting {
+  def isReported(
+      versionOpt: Option[String],
+      filters: Seq[ProblemFilter],
+      versionedFilters: Map[String, Seq[ProblemFilter]]
+  )(problem: Problem): Boolean = {
+    val versionMatchingFilters = versionOpt match {
+      case None => Seq.empty
+      case Some(version) =>
+        versionedFilters
+          // get all filters that apply to given module version or any version after it
+          .collect {
+            case (version2, filters)
+                if ProblemReporting.versionOrdering.gteq(version2, version) =>
+              filters
+          }.flatten
+    }
+
+    (versionMatchingFilters.iterator ++ filters).forall(filter =>
+      filter(problem)
+    )
+  }
+}

--- a/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/ProblemReportingExport.scala
+++ b/mill-mima-worker-impl/src/com/typesafe/tools/mima/core/ProblemReportingExport.scala
@@ -1,5 +1,0 @@
-package com.typesafe.tools.mima.core
-
-private[com] object MyProblemReporting {
-  val isReported = ProblemReporting.isReported _
-}


### PR DESCRIPTION
Functionality for `PublishModule` is still supported but it is required only at runtime, to allow checking on modules that don't extend `PublishModule`

Fixes #156 