### PR TITLE
Fix version printing in prettyDep

### DIFF
--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -169,7 +169,7 @@ trait Mima extends JavaModule with OfflineSupportModule {
     }
     Task.Command {
       def prettyDep(dep: Dep): String = {
-        s"${dep.dep.module.orgName}:${dep.dep.versionConstraint}"
+        s"${dep.dep.module.orgName}:${dep.dep.versionConstraint.asString}"
       }
       val log = Task.log
 


### PR DESCRIPTION
This should change
```
Found 2 issue when checking against com.lihaoyi:mill-libs-util_3:VersionConstraint.Lazy(1.0.0, [unparsed])
```
to
```
Found 2 issue when checking against com.lihaoyi:mill-libs-util_3:1.0.0
```