### PR TITLE
Pass past artifact version to ProblemReporting.isReported

### DIFF
--- a/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.scala
+++ b/mill-mima-worker-api/src/com/github/lolgab/mill/mima/worker/api/MimaWorkerApi.scala
@@ -20,7 +20,7 @@ trait MimaWorkerApi {
   ): Option[String]
 }
 
-case class Artifact(prettyDep: String, file: File)
+case class Artifact(prettyDep: String, file: File, version: String)
 
 sealed trait CheckDirection
 object CheckDirection {

--- a/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
+++ b/mill-mima/src/com/github/lolgab/mill/mima/Mima.scala
@@ -182,7 +182,7 @@ trait Mima extends JavaModule with OfflineSupportModule {
 
       val previous = resolvedMimaPreviousArtifacts().iterator.map {
         case (dep, artifact) =>
-          worker.api.Artifact(prettyDep(dep), artifact.path.toIO)
+          worker.api.Artifact(prettyDep(dep), artifact.path.toIO, dep.version)
       }.toSeq
 
       val checkDirection = mimaCheckDirection() match {


### PR DESCRIPTION
I think this fixes the version filters stuff, `mimaBackwardIssueFilters` and `mimaForwardIssueFilters`. Right now, mill-mima passes the current `publishVersion` to `ProblemReporting.isReported`, but this basically cannot work, given `ProblemReporting.isReported` [will only retain entries in the map whose version is higher or equal to it](https://github.com/lightbend-labs/mima/blob/0459a990e55ebd734761badee91dfa09761f30c9/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala#L24). So this PR changes this version to the one of the (published) artifact being compared to what's being built.