### PR TITLE
Migrate integration tests to Mill built-in test infrastructure

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -113,18 +113,20 @@ trait MillMimaCross
       mvn"com.lihaoyi::mill-testkit:${millVersion(millBinaryVersion)}"
     )
     def forkEnv = Task {
-      val artifact =
-        s"${millMima.pomSettings().organization}-${millMima.artifactId()}"
-          .replaceAll("[.-]", "_")
-      val localClasspathString =
-        millMima.localClasspath().map(_.path).mkString("\n")
+      val testRepos = Seq(
+        millMima.publishLocalTestRepo().path.toNIO.toUri.toASCIIString,
+        `mill-mima-worker-api`.publishLocalTestRepo().path.toNIO.toUri.toASCIIString,
+        `mill-mima-worker-impl`.publishLocalTestRepo().path.toNIO.toUri.toASCIIString
+      )
+      val repos = testRepos ++
+        Seq(Task.env.getOrElse("COURSIER_REPOSITORIES", "ivy2Local|central"))
       Map(
         "MILL_EXECUTABLE_PATH" -> millExecutable.assembly().path.toString,
-        "MILL_LOCAL_TEST_OVERRIDE_com_github_lolgab_mill_mima_mill1_3" -> localClasspathString
+        "COURSIER_REPOSITORIES" -> repos.mkString("|"),
+        "MILL_MIMA_TEST_VERSION" -> millMima.publishVersion()
       )
     }
 
-    // Create a Mill executable configured for testing our plugin
     object millExecutable extends JavaModule {
       def mvnDeps = Seq(
         mvn"com.lihaoyi:mill-runner-launcher_3:${millVersion(millBinaryVersion)}"

--- a/mill-mima/itest/resources/filters/build.mill
+++ b/mill-mima/itest/resources/filters/build.mill
@@ -1,6 +1,7 @@
-package build
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
 
-import $mvn.`com.github.lolgab::mill-mima::TEST`
+package build
 
 import mill._
 import mill.scalalib._
@@ -15,8 +16,8 @@ trait Common extends ScalaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
-  override def mimaBinaryIssueFilters = T {
+  override def mimaPreviousArtifacts = Task(Seq(mvn"org::prev:0.0.1"))
+  override def mimaBinaryIssueFilters = Task {
     Seq(ProblemFilter.exclude[Problem]("foo.Foo.*"))
   }
 }

--- a/mill-mima/itest/resources/java/build.mill
+++ b/mill-mima/itest/resources/java/build.mill
@@ -1,9 +1,9 @@
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
+
 package build
 
-import $ivy.`com.github.lolgab::mill-mima::TEST`
-
 import mill._
-
 import mill.scalalib._
 import mill.scalalib.publish._
 import com.github.lolgab.mill.mima._
@@ -15,6 +15,6 @@ trait Common extends JavaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  override def mimaPreviousArtifacts = T(Agg(ivy"org:prev:0.0.1"))
+  override def mimaPreviousArtifacts = Task(Seq(mvn"org:prev:0.0.1"))
   override def mimaCheckDirection = CheckDirection.Backward
 }

--- a/mill-mima/itest/resources/mima-version/build.mill
+++ b/mill-mima/itest/resources/mima-version/build.mill
@@ -1,9 +1,9 @@
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
+
 package build
 
-import $ivy.`com.github.lolgab::mill-mima::TEST`
-
 import mill._
-
 import mill.scalalib._
 import mill.scalalib.publish._
 import com.github.lolgab.mill.mima._
@@ -16,7 +16,7 @@ trait Common extends ScalaModule with PublishModule {
 }
 object prev extends Common
 object curr extends Common with Mima {
-  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
+  override def mimaPreviousArtifacts = Task(Seq(mvn"org::prev:0.0.1"))
   override def mimaCheckDirection = CheckDirection.Backward
   override def mimaVersion = "1.1.0"
 }

--- a/mill-mima/itest/resources/multi-previous-versions/build.mill
+++ b/mill-mima/itest/resources/multi-previous-versions/build.mill
@@ -1,15 +1,12 @@
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
+
 package build
 
-import $ivy.`com.github.lolgab::mill-mima::TEST`
-
 import mill._
-
 import mill.scalalib._
 import mill.scalalib.publish._
 import com.github.lolgab.mill.mima._
-import coursier.ivy.IvyRepository
-import mill.define.Target
-import os.Path
 
 trait Common extends ScalaModule with PublishModule {
   def scalaVersion = "2.13.4"
@@ -20,22 +17,20 @@ object prev extends Common {
   def publishVersion = "0.0.1"
 }
 object prev2 extends Common {
-  override def millSourcePath = curr.millSourcePath
+  override def moduleDir = curr.moduleDir
   override def artifactName = "prev"
   override def publishVersion = "0.0.2"
 }
 
 object curr extends Common with Mima {
   def publishVersion = "0.0.3"
-  def mimaPreviousArtifacts = T(
-    Agg(
-      ivy"org::prev:0.0.1",
-      ivy"org::prev:0.0.2"
+  def mimaPreviousArtifacts = Task(
+    Seq(
+      mvn"org::prev:0.0.1",
+      mvn"org::prev:0.0.2"
     )
   )
 }
-
-val repo = sys.props("ivy.home") + "/local"
 
 def verify() = Task.Command {
   assert(curr.mimaPreviousArtifacts().iterator.size == 2)

--- a/mill-mima/itest/resources/not-publish-module/build.mill
+++ b/mill-mima/itest/resources/not-publish-module/build.mill
@@ -1,9 +1,9 @@
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
+
 package build
 
-import $ivy.`com.github.lolgab::mill-mima::TEST`
-
 import mill._
-
 import mill.scalalib._
 import mill.scalalib.publish._
 import com.github.lolgab.mill.mima._
@@ -16,7 +16,7 @@ object prev extends ScalaModule with PublishModule {
 }
 object curr extends ScalaModule with Mima {
   def scalaVersion = "2.13.4"
-  override def mimaPreviousArtifacts = T(Agg(ivy"org::prev:0.0.1"))
+  override def mimaPreviousArtifacts = Task(Seq(mvn"org::prev:0.0.1"))
 }
 
 def verify() = Task.Command {

--- a/mill-mima/itest/resources/previous-versions/build.mill
+++ b/mill-mima/itest/resources/previous-versions/build.mill
@@ -1,7 +1,8 @@
-package build
+//| mvnDeps:
+//|   - com.github.lolgab::mill-mima::TEST
+//|   - org.scalameta::munit:0.7.27
 
-import $ivy.`com.github.lolgab::mill-mima::TEST`
-import $ivy.`org.scalameta::munit:0.7.27`
+package build
 
 import com.github.lolgab.mill.mima._
 import mill._
@@ -10,33 +11,35 @@ import mill.scalalib.publish._
 import mill.scalajslib.ScalaJSModule
 import munit.Assertions._
 
-trait Common extends ScalaModule with PublishModule with Mima { outer =>
+trait Common extends ScalaModule with PublishModule with Mima {
   def scalaVersion = "2.13.6"
   def publishVersion = "0.0.1"
   override def artifactName = "prev"
   def pomSettings =
     PomSettings("", organization = "org", "", Seq(), VersionControl(), Seq())
-  trait Js extends Common with ScalaJSModule {
-    override def millSourcePath = outer.millSourcePath
-    override def scalaJSVersion = "1.6.0"
-    override def artifactName = "prev-js"
-    override def mimaPreviousVersions = outer.mimaPreviousVersions
-  }
 }
+
+trait CommonJs extends Common with ScalaJSModule {
+  override def moduleDir = super.moduleDir / os.up
+  override def scalaJSVersion = "1.6.0"
+  override def artifactName = "prev-js"
+}
+
 object prev extends Common {
-  object js extends Js
+  object js extends CommonJs
 }
 object curr extends Common with Mima {
-  override def mimaPreviousVersions = T(Seq("0.0.1"))
-  object js extends Js
+  override def mimaPreviousVersions = Task(Seq("0.0.1"))
+  object js extends CommonJs {
+    override def mimaPreviousVersions = Task(Seq("0.0.1"))
+  }
 }
 
 def verify() = Task.Command {
-  // tests mimaPreviousVersions
-  assertEquals(curr.mimaPreviousArtifacts(), Agg(ivy"org:prev_2.13:0.0.1"))
+  assertEquals(curr.mimaPreviousArtifacts(), Seq(mvn"org:prev_2.13:0.0.1"))
   assertEquals(
     curr.js.mimaPreviousArtifacts(),
-    Agg(ivy"org:prev-js_sjs1_2.13:0.0.1")
+    Seq(mvn"org:prev-js_sjs1_2.13:0.0.1")
   )
 }
 

--- a/mill-mima/itest/src/IntegrationTests.scala
+++ b/mill-mima/itest/src/IntegrationTests.scala
@@ -5,28 +5,23 @@ import utest._
 object IntegrationTests extends TestSuite {
   val resourceFolder = os.Path(sys.env("MILL_TEST_RESOURCE_DIR"))
   val millExecutable = os.Path(sys.env("MILL_EXECUTABLE_PATH"))
+  val testVersion = sys.env("MILL_MIMA_TEST_VERSION")
   val tempDir = os.temp.dir()
-
-  // publishLocal mill-mima on temporary ivy.home
-  os.call(
-    cmd = (
-      "./mill",
-      "--no-build-lock",
-      "__.publishLocal",
-      "--localIvyRepo",
-      tempDir / "local"
-    ),
-    cwd = os.Path(sys.env("MILL_WORKSPACE_ROOT")),
-    env = Map("MILL_MIMA_FORCED_VERSION" -> "TEST")
-  )
 
   def tests: Tests = Tests {
 
-    def buildTester(folder: String) = IntegrationTester(
-      daemonMode = false,
-      workspaceSourcePath = resourceFolder / folder,
-      millExecutable = millExecutable
-    )
+    def buildTester(folder: String) = {
+      val tester = IntegrationTester(
+        daemonMode = false,
+        workspaceSourcePath = resourceFolder / folder,
+        millExecutable = millExecutable
+      )
+      tester.modifyFile(
+        tester.workspacePath / "build.mill",
+        _.replace("::TEST", s"::$testVersion")
+      )
+      tester
+    }
 
     extension (tester: IntegrationTester) {
       def publishLocal(module: String) =
@@ -75,7 +70,6 @@ object IntegrationTests extends TestSuite {
       assert(res2.isSuccess)
 
       val res3 = tester.myEval("verifyFail")
-      assert(!res3.isSuccess)
       assert(!res3.isSuccess)
 
       val res4 = tester.myEval("verifyFailJs")


### PR DESCRIPTION
## Summary
- Replace the old `mill-integrationtest`-style pattern with Mill's native `publishLocalTestRepo` + `COURSIER_REPOSITORIES` approach for plugin testing
- Update all test resource `build.mill` files from `$ivy.`/`$mvn.` imports to the `//| mvnDeps:` header format and modern Mill 1.x syntax (`Task`, `Seq`, `mvn"..."`)
- Remove the manual `os.call("./mill", "__.publishLocal")` from test initialization, simplifying the test setup

## Test plan
- [x] All 6 integration tests pass locally (simple, filters, previous-versions, java, not-publish-module, mima-version)
- [ ] CI passes on GitHub Actions

Made with [Cursor](https://cursor.com)